### PR TITLE
More env config options

### DIFF
--- a/mathy_envs/env.py
+++ b/mathy_envs/env.py
@@ -15,6 +15,7 @@ from mathy_core.rules import (
     DistributiveMultiplyRule,
     VariableMultiplyRule,
 )
+from mathy_core.tree import BinaryTreeNode
 from mathy_core.util import compare_expression_string_values, raise_with_history
 
 from . import time_step
@@ -232,7 +233,7 @@ class MathyEnv:
                         features, self.get_lose_signal(env_state)
                     )
 
-                # NOTE: the reward is scaled by how many times this state has been visited
+                # NOTE: the reward is scaled by # of times this state has been visited
                 return time_step.transition(
                     features,
                     reward=EnvRewards.PREVIOUS_LOCATION * list_count,
@@ -495,13 +496,13 @@ class MathyEnv:
     ) -> Optional[MathExpression]:
         """Get the token that is `index` from the left of the expression"""
         count = 0
-        result = None
+        result: Optional[MathExpression] = None
 
         def visit_fn(
-            node: MathExpression, depth: int, data: Any
+            node: BinaryTreeNode, depth: int, data: Any
         ) -> Optional[VisitStop]:
             nonlocal result, count
-            result = node
+            result = node  # type:ignore
             if count == index:
                 return STOP
             count = count + 1

--- a/mathy_envs/env.py
+++ b/mathy_envs/env.py
@@ -46,6 +46,7 @@ class MathyEnv:
     valid_rules_cache: Dict[str, List[int]]
     invalid_action_response: InvalidActionResponses
     previous_state_penalty: bool
+    preferred_term_commute: bool
 
     def __init__(
         self,
@@ -57,6 +58,7 @@ class MathyEnv:
         reward_discount: float = 0.99,
         max_seq_len: int = 128,
         previous_state_penalty: bool = True,
+        preferred_term_commute: bool = False,
     ):
         self.discount = reward_discount
         self.previous_state_penalty = previous_state_penalty
@@ -66,7 +68,9 @@ class MathyEnv:
         self.invalid_action_response = invalid_action_response
         self.parser = ExpressionParser()
         if rules is None:
-            self.rules = MathyEnv.core_rules()
+            self.rules = MathyEnv.core_rules(
+                preferred_term_commute=preferred_term_commute
+            )
         else:
             self.rules = rules
         self.valid_actions_mask_cache = dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 colr
 pydantic>=1.0.0
 wasabi
-mathy_core>=0.8.0
+mathy_core>=0.8.2

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -189,6 +189,21 @@ def test_mathy_env_invalid_action_behaviors():
     assert env_state.to_observation([]) is not None
 
 
+def test_mathy_env_preferred_term_commute():
+    rule_idx = 1
+    problem = "5y"
+    env_state = MathyEnvState(problem=problem, max_moves=1)
+
+    env = MathyEnv(preferred_term_commute=False)
+    assert isinstance(env.rules[rule_idx], CommutativeSwapRule), "update rule_idx"
+    commute_nodes = env.get_valid_moves(env_state)[rule_idx]
+    assert 1 not in commute_nodes, "shouldn't be able to commute preferred order terms"
+
+    env = MathyEnv(preferred_term_commute=True)
+    commute_nodes = env.get_valid_moves(env_state)[rule_idx]
+    assert 1 in commute_nodes, "should be able to commute preferred order terms"
+
+
 def test_mathy_env_previous_state_penalty():
     """When previous_state_penalty=True, a negative reward is given when
     revisiting already seen problem states. If an agent revisits the


### PR DESCRIPTION
Add `previous_state_penalty` which when set to true, gives the agent a negative reward that scales up with each time a state is revisited, and terminates the episode after the third visit to one unique state. The intuition behind this is that while simplifying or solving problems in an optimal way, there is no good reason to revisit the same state twice.

Add `preferred_term_commute` to allow toggling the CommutativeSwap rule's bias for keeping terms in a natural order, e.g. "4x" instead of "x * 4". When set to true, the transformation from "4x" to "x * 4" is allowed. When set to false, the commutative swap rule will not apply to the 4x subtree.