### PR TITLE
Fix/normalize problem type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 build
 coverage
 .ipynb_checkpoints
+training/

--- a/mathy_envs/gym/gym_goal_env.py
+++ b/mathy_envs/gym/gym_goal_env.py
@@ -66,7 +66,7 @@ class MathyGymGoalEnv(gym.GoalEnv):
         mask = len(self.mathy.rules) * self.mathy.max_seq_len
         values = self.mathy.max_seq_len
         nodes = self.mathy.max_seq_len
-        type = 2
+        type = 4
         time = 1
         obs_size = mask + values + nodes + type + time
         self.observation_space = spaces.Dict(

--- a/mathy_envs/gym/mathy_gym_env.py
+++ b/mathy_envs/gym/mathy_gym_env.py
@@ -54,7 +54,7 @@ class MathyGymEnv(gym.Env):
             mask = len(self.mathy.rules) * self.mathy.max_seq_len
             values = self.mathy.max_seq_len
             nodes = self.mathy.max_seq_len
-            type = 2
+            type = 4
             time = 1
             obs_size = mask + values + nodes + type + time
             self.observation_space = spaces.Box(
@@ -66,7 +66,7 @@ class MathyGymEnv(gym.Env):
             # obs = (
             #      nodes_tensor(1, 128),
             #      values_tensor(1, 128),
-            #      type_tensor(1, 2),
+            #      type_tensor(1, 4),
             #      time_tensor(1, 1)
             # )
             raise NotImplementedError(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -13,13 +13,28 @@ def test_state_to_observation():
 
 
 def test_state_to_observation_normalization():
-    """to_observation has defaults to allow calling with no arguments"""
+    """normalize argument converts all values to range 0.0-1.0"""
     env_state = MathyEnvState(problem="4+2")
     obs: MathyObservation = env_state.to_observation(normalize=False)
     assert np.max(obs.values) == 4.0
 
     norm: MathyObservation = env_state.to_observation(normalize=True)
     assert np.max(norm.values) == 1.0
+
+
+def test_state_to_observation_normalized_problem_type():
+    """normalize argument converts all values and type hash to range 0.0-1.0"""
+    env_state = MathyEnvState(problem="4+2")
+    obs: MathyObservation = env_state.to_observation()
+    print(obs.type)
+    assert np.max(obs.time) <= 1.0
+    assert np.min(obs.time) >= 0.0
+
+    assert np.max(obs.values) <= 1.0
+    assert np.min(obs.values) >= 0.0
+
+    assert np.max(obs.type) <= 1.0
+    assert np.min(obs.type) >= 0.0
 
 
 def test_state_encodes_hierarchy():


### PR DESCRIPTION
Environment observations begin with the environment type hash values, which were not normalized to 0.0-1.0 range like the rest of the observation. This causes agents to have to learn to ignore the large values before they can learn from the relatively small values that follow it. 

This normalizes the problem type hash values into range 0.0-1.0 and makes them deterministic by using zlib's `adler32` utility.

![Screen Shot 2020-11-29 at 6 05 59 PM](https://user-images.githubusercontent.com/101493/100561485-ea614780-326d-11eb-81a5-75a7f9e8d921.png)
![Screen Shot 2020-11-29 at 6 08 31 PM](https://user-images.githubusercontent.com/101493/100561487-eaf9de00-326d-11eb-81af-e6a4f1818a82.png)
