### PR TITLE
fix(gym): info returned was always {} when stepping

### DIFF
--- a/mathy_envs/gym/mathy_gym_env.py
+++ b/mathy_envs/gym/mathy_gym_env.py
@@ -83,7 +83,7 @@ class MathyGymEnv(gym.Env[NDArray[Any], np.int64]):
         if terminated or truncated:
             info["win"] = transition.reward > 0.0
 
-        obs, info = self._observe(self.state)
+        obs, _ = self._observe(self.state)
         return obs, transition.reward, terminated, truncated, info
 
     def _observe(self, state: MathyEnvState) -> Tuple[np.ndarray, dict]:

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -42,6 +42,32 @@ def test_gym_instantiate_envs():
         assert observation is not None
 
 
+def test_gym_step_info():
+    import gymnasium as gym
+
+    from mathy_envs.gym import MathyGymEnv
+
+    all_envs = gym.registry.values()
+    # Filter to just mathy registered envs
+    mathy_gym_envs = [e for e in all_envs if e.id.startswith("mathy-")]
+
+    assert len(mathy_gym_envs) > 0
+
+    # Each env can be created and produce an initial observation without
+    # special configuration.
+    for gym_env_spec in mathy_gym_envs:
+        print(f"Testing {gym_env_spec.id}...")
+        wrapper_env: MathyGymEnv = gym.make(gym_env_spec.id)  # type:ignore
+        assert wrapper_env is not None
+
+        obs = wrapper_env.reset()
+        print("initial observation:", obs)
+        action = wrapper_env.action_space.sample()
+        obs, reward, terminated, truncated, info = wrapper_env.step(action)
+        for key in ["valid", "done", "truncated", "transition"]:
+            assert key in info, f"info should have a string key {key}"
+
+
 def test_gym_env_spaces():
     import gymnasium as gym
 


### PR DESCRIPTION
- this manifested in mathy CLI where the swarm solver was broken because it relied on inspecting the returned info for terminal information